### PR TITLE
Allow usage of Symfony Components ~4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,9 +17,9 @@
     "require": {
         "ext-zip": "*",
         "guzzlehttp/guzzle": "~4.0|~5.0|~6.0",
-        "symfony/console": "~2.3|~3.0",
-        "symfony/filesystem": "~2.3|~3.0",
-        "symfony/process": "~2.3|~3.0",
+        "symfony/console": "~2.3|~3.0|~4.0",
+        "symfony/filesystem": "~2.3|~3.0|~4.0",
+        "symfony/process": "~2.3|~3.0|~4.0",
         "vlucas/phpdotenv": "~2.2"
     },
     "bin": [


### PR DESCRIPTION
Use `~2.3|~3.0|~4.0` instead of `~2.3|~3.0`